### PR TITLE
Use pinned pipenv in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM python:3.6
 MAINTAINER Dave Hunt <dave.hunt@gmail.com>
 
 WORKDIR /src
-COPY Pipfile* /src/
-RUN pip install pipenv && \
+COPY Pipfile* pipenv.txt /src/
+RUN pip install -r pipenv.txt && \
   pipenv install --system --deploy
 
 COPY active_data.py generate.py template.html /src/


### PR DESCRIPTION
@davehunt r?

```
To https://github.com/stephendonner/fxtest-report
 * [new branch]      pip-pipenv -> pip-pipenv
Stephens-MBP:fxtest-report stephendonner$ docker build -t fxtest-report .
Sending build context to Docker daemon  833.5kB
Step 1/8 : FROM python:3.6
3.6: Pulling from library/python
f2b6b4884fc8: Already exists 
4fb899b4df21: Already exists 
74eaa8be7221: Already exists 
2d6e98fe4040: Already exists 
414666f7554d: Pull complete 
135a494fed80: Pull complete 
6ca3f38fdd4d: Pull complete 
dd97f9c17d4f: Pull complete 
Digest: sha256:25185c23595ca69dfba95d50150e52775794250773e271708adc6999af913be8
Status: Downloaded newer image for python:3.6
 ---> 500d0dca385d
Step 2/8 : MAINTAINER Dave Hunt <dave.hunt@gmail.com>
 ---> Running in 1f1ecbd0dcfc
Removing intermediate container 1f1ecbd0dcfc
 ---> ab4fe7f33ea2
Step 3/8 : WORKDIR /src
Removing intermediate container 2edcb24db3e3
 ---> 33a9ffd759d8
Step 4/8 : COPY Pipfile* pipenv.txt /src/
 ---> d9f2f621330b
Step 5/8 : RUN pip install -r pipenv.txt &&   pipenv install --system --deploy
 ---> Running in 352e0f5a6881
Collecting pipenv==10.1.2 (from -r pipenv.txt (line 1))
  Downloading pipenv-10.1.2.tar.gz (3.9MB)
Collecting virtualenv (from pipenv==10.1.2->-r pipenv.txt (line 1))
  Downloading virtualenv-15.1.0-py2.py3-none-any.whl (1.8MB)
Collecting pew>=0.1.26 (from pipenv==10.1.2->-r pipenv.txt (line 1))
  Downloading pew-1.1.2-py2.py3-none-any.whl
Requirement already satisfied: pip>=9.0.1 in /usr/local/lib/python3.6/site-packages (from pipenv==10.1.2->-r pipenv.txt (line 1))
Collecting requests>2.18.0 (from pipenv==10.1.2->-r pipenv.txt (line 1))
  Downloading requests-2.18.4-py2.py3-none-any.whl (88kB)
Collecting urllib3>=1.21.1 (from pipenv==10.1.2->-r pipenv.txt (line 1))
  Downloading urllib3-1.22-py2.py3-none-any.whl (132kB)
Requirement already satisfied: setuptools>=17.1 in /usr/local/lib/python3.6/site-packages (from pew>=0.1.26->pipenv==10.1.2->-r pipenv.txt (line 1))
Collecting virtualenv-clone>=0.2.5 (from pew>=0.1.26->pipenv==10.1.2->-r pipenv.txt (line 1))
  Downloading virtualenv_clone-0.3.0-py2.py3-none-any.whl
Collecting idna<2.7,>=2.5 (from requests>2.18.0->pipenv==10.1.2->-r pipenv.txt (line 1))
  Downloading idna-2.6-py2.py3-none-any.whl (56kB)
Collecting chardet<3.1.0,>=3.0.2 (from requests>2.18.0->pipenv==10.1.2->-r pipenv.txt (line 1))
  Downloading chardet-3.0.4-py2.py3-none-any.whl (133kB)
Collecting certifi>=2017.4.17 (from requests>2.18.0->pipenv==10.1.2->-r pipenv.txt (line 1))
  Downloading certifi-2018.1.18-py2.py3-none-any.whl (151kB)
Building wheels for collected packages: pipenv
  Running setup.py bdist_wheel for pipenv: started
  Running setup.py bdist_wheel for pipenv: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/e6/d7/a3/1ca2bd6facf67e58a0823a971825972accb1aff7014803a6a8
Successfully built pipenv
Installing collected packages: virtualenv, virtualenv-clone, pew, idna, chardet, urllib3, certifi, requests, pipenv
Successfully installed certifi-2018.1.18 chardet-3.0.4 idna-2.6 pew-1.1.2 pipenv-10.1.2 requests-2.18.4 urllib3-1.22 virtualenv-15.1.0 virtualenv-clone-0.3.0
Pipfile.lock not found, creating…
Locking [dev-packages] dependencies…
Locking [packages] dependencies…
Updated Pipfile.lock (15db50)!
Installing dependencies from Pipfile.lock (15db50)…
Removing intermediate container 352e0f5a6881
 ---> 2fe6be962a0f
Step 6/8 : COPY active_data.py generate.py template.html /src/
 ---> 478857217901
Step 7/8 : COPY queries /src/queries/
 ---> 066c8c5e8a6c
Step 8/8 : CMD python generate.py -o report.html
 ---> Running in 97b5be7a4d0b
Removing intermediate container 97b5be7a4d0b
 ---> 28426e55493c
Successfully built 28426e55493c
Successfully tagged fxtest-report:latest
Stephens-MBP:fxtest-report stephendonner$ docker run -t fxtest-report 
```